### PR TITLE
Fix for "/sms break -loc x,y,z,world"

### DIFF
--- a/src/main/java/me/desht/scrollingmenusign/commands/RemoveViewCommand.java
+++ b/src/main/java/me/desht/scrollingmenusign/commands/RemoveViewCommand.java
@@ -34,11 +34,10 @@ public class RemoveViewCommand extends AbstractCommand {
 		} else if (args.length == 2 && args[0].equals("-loc")) {
 			// detaching a view by location
 			try {
-				view = SMSView.getViewForLocation(MiscUtil.parseLocation(args[0], sender));
+				view = SMSView.getViewForLocation(MiscUtil.parseLocation(args[1], sender));
 			} catch (IllegalArgumentException e) {
 				throw new SMSException(e.getMessage());
 			}
-			view = SMSView.getViewForLocation(MiscUtil.parseLocation(args[0], sender));
 		} else if (sender instanceof Player && (view = SMSMapView.getHeldMapView((Player)sender)) != null) {
 			// detaching a map view - nothing else to check here
 		} else if (args.length == 0) {


### PR DESCRIPTION
Error "Invalid number in -loc" cause of using wrong args-part.

Hint: The Wiki-Page http://dev.bukkit.org/server-mods/scrollingmenusign/pages/usage/removing-views/ is out of date ("missing -loc, and has world bevor coords instead after")
